### PR TITLE
imlibpurpleservice: Migrate to Enhanced ACG

### DIFF
--- a/files/sysbus/com.palm.imlibpurple.api.json.in
+++ b/files/sysbus/com.palm.imlibpurple.api.json.in
@@ -1,14 +1,5 @@
 {
-    "applications": [
-        "com.palm.imlibpurple/loginForTesting",
-        "com.palm.imlibpurple/onCreate",
-        "com.palm.imlibpurple/onDelete",
-        "com.palm.imlibpurple/onEnabled",
-        "com.palm.imlibpurple/loginStateChanged",
-        "com.palm.imlibpurple/sendIM",
-        "com.palm.imlibpurple/sendCommand"
-    ],
-    "services": [
+    "imlibpurple-service.operation": [
         "com.palm.imlibpurple/loginForTesting",
         "com.palm.imlibpurple/onCreate",
         "com.palm.imlibpurple/onDelete",

--- a/files/sysbus/com.palm.imlibpurple.perm.json.in
+++ b/files/sysbus/com.palm.imlibpurple.perm.json.in
@@ -1,10 +1,7 @@
 {
     "com.palm.imlibpurple": [
-        "services",
-        "applications",
-        "applications.internal",
-        "database",
-        "database.internal",
-        "activities.manage"
+        "imlibpurple-service.operation",
+        "database.operation",
+        "activity.operation"
     ]
 }

--- a/files/sysbus/com.palm.imlibpurple.role.json.in
+++ b/files/sysbus/com.palm.imlibpurple.role.json.in
@@ -1,5 +1,6 @@
 {
     "exeName":"@WEBOS_INSTALL_SBINDIR@/imlibpurpleservice",
+    "trustLevel" : "oem",
     "type":"regular",
     "allowedNames":["com.palm.imlibpurple"],
     "permissions":[


### PR DESCRIPTION
In order to be able to use latest components from upstream webOS OSE.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
